### PR TITLE
Added support for ContainerInfo for mesos 0.19.0

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -134,6 +134,24 @@ default values.
     </description>
   </property>
 
+  <!-- If you're using a custom Mesos Containerizer -->
+  <property>
+    <name>mapred.mesos.container.image</name>
+    <value>docker:///ubuntu</value>
+    <description>
+      If you're using a custom Mesos Containerizer (like the External Containerizer)
+      that uses images, you can set this option to cause Hadoop TaskTrackers to
+      be launched within this container image.
+    </description>
+  </property>
+  <property>
+    <name>mapred.mesos.container.options</name>
+    <value></value>
+    <description>
+      Comma separated list of options to pass to the containerizer. The meaning
+      of this entirely depends on the containerizer in use.
+    </description>
+  </property>
 
   <!-- Metrics -->
   <property>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.apache.mesos</groupId>
     <artifactId>hadoop-mesos</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
 
     <properties>
         <encoding>UTF-8</encoding>
@@ -15,7 +15,7 @@
         <!-- runtime deps versions -->
         <commons-logging.version>1.1.1</commons-logging.version>
         <hadoop-core.version>1.2.1</hadoop-core.version>
-        <mesos.version>0.15.0</mesos.version>
+        <mesos.version>0.19.0</mesos.version>
         <protobuf.version>2.4.1</protobuf.version>
         <metrics.version>3.0.2</metrics.version>
         <snappy-java.version>1.0.4.1</snappy-java.version>

--- a/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
+++ b/src/main/java/org/apache/hadoop/mapred/ResourcePolicy.java
@@ -335,7 +335,6 @@ public class ResourcePolicy {
         }
 
         // Command info differs when performing a local run.
-        CommandInfo commandInfo = null;
         String master = scheduler.conf.get("mapred.mesos.master");
 
         if (master == null) {
@@ -364,10 +363,30 @@ public class ResourcePolicy {
           command = "env ; ./bin/hadoop org.apache.hadoop.mapred.MesosExecutor";
         }
 
-        commandInfo = CommandInfo.newBuilder()
+        CommandInfo.Builder commandInfo = CommandInfo.newBuilder();
+        commandInfo
             .setEnvironment(envBuilder)
             .setValue(String.format("cd %s && %s", directory, command))
-            .addUris(CommandInfo.URI.newBuilder().setValue(uri)).build();
+            .addUris(CommandInfo.URI.newBuilder().setValue(uri));
+
+        // Populate ContainerInfo if needed
+        String containerImage = scheduler.conf.get("mapred.mesos.container.image");
+        String[] containerOptions = scheduler.conf.getStrings("mapred.mesos.container.options");
+
+        if (containerImage != null || containerOptions.length > 0) {
+          CommandInfo.ContainerInfo.Builder containerInfo =
+              CommandInfo.ContainerInfo.newBuilder();
+
+          if (containerImage != null) {
+            containerInfo.setImage(containerImage);
+          }
+
+          for (int i = 0; i < containerOptions.length; i++) {
+            containerInfo.addOptions(containerOptions[i]);
+          }
+
+          commandInfo.setContainer(containerInfo.build());
+        }
 
         // Create a configuration from the current configuration and
         // override properties as appropriate for the TaskTracker.
@@ -474,7 +493,7 @@ public class ResourcePolicy {
                             .setType(Value.Type.SCALAR)
                             .setRole(memRole)
                             .setScalar(Value.Scalar.newBuilder().setValue(containerMem)))
-                    .setCommand(commandInfo))
+                    .setCommand(commandInfo.build()))
             .setData(ByteString.copyFrom(bytes))
             .build();
 


### PR DESCRIPTION
This pull request implements a very simple way of configuring the container image (and options) passed when launching Task Trackers. This can work especially well when coupled with the a [Docker Containerizer](http://github.com/mesosphere/deimos) as a way of managing system dependencies requires for running Hadoop jobs.
